### PR TITLE
add weight file directly to this repo 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.weights filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Tested on Jetson nano 2GB.
 ## Build
 ```
 git clone --recursive https://github.com/vuhailongkl97/iot.git
-cd iot && git lfs pull
+cd iot 
 mkdir build && cd build
 cmake -DIMAGE_DBG=1 ..  &&  make
 --------------------


### PR DESCRIPTION
### Reason
due to limit bandwidth from GitHub and size of the weight file also < 25MB -> ok 

src :
https://github.com/AlexeyAB/darknet/releases/download/darknet_yolo_v4_pre/yolov4-tiny.weights